### PR TITLE
DEVC-1150: added functionality to download latest devon-ide-scripts from the sidebar

### DIFF
--- a/main/index.ts
+++ b/main/index.ts
@@ -114,6 +114,17 @@ function getDevonIdeScripts() {
     });
 }
 
+function getLatestDevonIdeScript() {
+  new DevonInstancesService()
+    .getLatestDevonIdeScriptsFromMaven()
+    .then((instance) => {
+      mainWindow.webContents.send('get:latestDevonIdeScript', instance);
+    })
+    .catch(() => {
+      mainWindow.webContents.send('get:latestDevonIdeScript', null);
+    });
+}
+
 // Finding out Devonfw Ide Instances
 function countInstance() {
   new DevonInstancesService()
@@ -220,6 +231,7 @@ terminalService.allCommands(null, null);
 // Finding out Devonfw Ide
 ipcMain.on('find:devonfw', countInstance);
 ipcMain.on('find:devonfwInstances', getDevonInstancesPath);
+ipcMain.on('find:latestDevonIdeScript', getLatestDevonIdeScript);
 ipcMain.on('find:workspaceProjects', (e, option) => {
   getWorkspaceProject(option);
 });

--- a/main/index.ts
+++ b/main/index.ts
@@ -22,6 +22,7 @@ import {
   checkProfileStatus,
   getDashboardProfile,
 } from './modules/profile-setup/handle-profile-setup';
+import { checkForDevonUpdates } from './modules/devon-updates/handle-devon-updates';
 import { ProjectDeleteListener } from './modules/projects/classes/listeners/project-delete-listener';
 import { OpenProjectIDEListener } from './modules/projects/classes/listeners/open-project-ide-listener';
 import { UserProfile } from './modules/shared/models/user-profile';
@@ -111,17 +112,6 @@ function getDevonIdeScripts() {
     })
     .catch(() => {
       mainWindow.webContents.send('get:devonIdeScripts', []);
-    });
-}
-
-function getLatestDevonIdeScript() {
-  new DevonInstancesService()
-    .getLatestDevonIdeScriptsFromMaven()
-    .then((instance) => {
-      mainWindow.webContents.send('get:latestDevonIdeScript', instance);
-    })
-    .catch(() => {
-      mainWindow.webContents.send('get:latestDevonIdeScript', null);
     });
 }
 
@@ -231,7 +221,7 @@ terminalService.allCommands(null, null);
 // Finding out Devonfw Ide
 ipcMain.on('find:devonfw', countInstance);
 ipcMain.on('find:devonfwInstances', getDevonInstancesPath);
-ipcMain.on('find:latestDevonIdeScript', getLatestDevonIdeScript);
+ipcMain.on('find:checkForUpdates', () => checkForDevonUpdates(mainWindow));
 ipcMain.on('find:workspaceProjects', (e, option) => {
   getWorkspaceProject(option);
 });

--- a/main/modules/devon-updates/handle-devon-updates.ts
+++ b/main/modules/devon-updates/handle-devon-updates.ts
@@ -1,0 +1,63 @@
+import { DevonInstancesService } from '../../services/devon-instances/devon-instances.service';
+import { DevonfwConfig } from '../../models/devonfw-dists.model';
+import { BrowserWindow } from 'electron';
+import { DevonUpdateResponse } from '../shared/models/devon-update-response';
+
+export function checkForDevonUpdates(mainWindow: BrowserWindow): void {
+  new DevonInstancesService()
+    .getLatestDevonIdeScriptsFromMaven()
+    .then((instance) => {
+      getLocalInstalledVersions(mainWindow, instance.version);
+    })
+    .catch(() => {
+      sendUpdateUnavailable(mainWindow);
+    });
+}
+
+function getLocalInstalledVersions(
+  mainWindow: BrowserWindow,
+  latestVersion: string
+) {
+  new DevonInstancesService()
+    .getAllUserCreatedDevonInstances()
+    .then((instances: DevonfwConfig) => {
+      if (instances.distributions.length) {
+        const localVersions = instances.distributions.map(
+          (i) => i.ideConfig.version
+        );
+        checkUpdateRequired(mainWindow, localVersions, latestVersion);
+      }
+    })
+    .catch(() => {
+      sendUpdateUnavailable(mainWindow);
+    });
+}
+
+function checkUpdateRequired(
+  mainWindow: BrowserWindow,
+  localVersions: string[],
+  latestVersion: string
+) {
+  if (!localVersions.includes(latestVersion)) {
+    const latestMachineVersion = getLocalLatestVersion(localVersions);
+    const response: DevonUpdateResponse = {
+      updateAvailable: true,
+      latestLocalVersion: latestMachineVersion,
+      latestAvailableVersion: latestVersion,
+    };
+    mainWindow.webContents.send('get:checkForUpdates', response);
+  } else sendUpdateUnavailable(mainWindow);
+}
+
+function getLocalLatestVersion(versions: string[]) {
+  return versions.reduce((currentVersion, maxVersion) =>
+    currentVersion > maxVersion ? currentVersion : maxVersion
+  );
+}
+
+function sendUpdateUnavailable(mainWindow: BrowserWindow) {
+  const response: DevonUpdateResponse = {
+    updateAvailable: false,
+  };
+  mainWindow.webContents.send('get:checkForUpdates', response);
+}

--- a/main/modules/shared/models/devon-update-response.ts
+++ b/main/modules/shared/models/devon-update-response.ts
@@ -1,0 +1,5 @@
+export interface DevonUpdateResponse {
+  updateAvailable: boolean;
+  latestLocalVersion?: string;
+  latestAvailableVersion?: string;
+}

--- a/main/services/devon-instances/devon-instances.service.ts
+++ b/main/services/devon-instances/devon-instances.service.ts
@@ -156,6 +156,35 @@ export class DevonInstancesService implements SaveDetails {
     return ideScriptsPromise;
   }
 
+  getLatestDevonIdeScriptsFromMaven(): Promise<DevonIdeScripts> {
+    let ideScript: DevonIdeScripts;
+    let data = '';
+    const ideScriptPromise = new Promise<DevonIdeScripts>((resolve, reject) => {
+      https
+        .get(
+          'https://search.maven.org/classic/solrsearch/select?q=a%3A%22devonfw-ide-scripts%22&rows=20&wt=json',
+          (res) => {
+            res.on('data', (d) => {
+              data += d;
+            });
+            res.on('end', () => {
+              const jsonData = JSON.parse(data);
+              const latestIdeScript = jsonData['response']['docs'][0];
+              ideScript = {
+                version: latestIdeScript.latestVersion,
+                updated: latestIdeScript.timestamp,
+              };
+              resolve(ideScript);
+            });
+          }
+        )
+        .on('error', (e) => {
+          reject('error: ' + e);
+        });
+    });
+    return ideScriptPromise;
+  }
+
   /* Checking projectinfo.json is exists?, if exits overriding data or 
     creating a json file with project details
   */

--- a/renderer/modules/home/components/view-dashboard-projects-detail/ViewDashboardProjectsDetail.styles.ts
+++ b/renderer/modules/home/components/view-dashboard-projects-detail/ViewDashboardProjectsDetail.styles.ts
@@ -11,6 +11,7 @@ export const useDashboardDetailsStyles = makeStyles({
     justifyContent: 'space-evenly',
     color: '#0075B3',
     paddingTop: '1em',
+    marginTop: '2em',
   },
   showChartIcon: {
     fontWeight: 'bold',

--- a/renderer/modules/home/components/welcome-to-devonfw/welcome-to-devonfw.tsx
+++ b/renderer/modules/home/components/welcome-to-devonfw/welcome-to-devonfw.tsx
@@ -28,7 +28,6 @@ export default function WelcomeToDevonfw(): JSX.Element {
       (_: IpcRendererEvent, arg: { total: number; received: number }) => {
         setTotal(arg.total);
         setReceived(arg.received);
-        setDownloadProgress(true);
         setDownloadStatusMsg('');
       }
     );
@@ -36,12 +35,14 @@ export default function WelcomeToDevonfw(): JSX.Element {
     global.ipcRenderer.on(
       'download completed',
       (_: IpcRendererEvent, arg: string) => {
-        setDownloadProgress(false);
-        setDownloadStatusMsg('Download was ' + arg + '.');
-        if (arg === 'completed') {
-          setDownloadStatusMsgColor('success.main');
-        } else {
-          setDownloadStatusMsgColor('error.main');
+        if (downloadProgress) {
+          setDownloadProgress(false);
+          setDownloadStatusMsg('Download was ' + arg + '.');
+          if (arg === 'completed') {
+            setDownloadStatusMsgColor('success.main');
+          } else {
+            setDownloadStatusMsgColor('error.main');
+          }
         }
       }
     );
@@ -57,7 +58,7 @@ export default function WelcomeToDevonfw(): JSX.Element {
         }
       }
     );
-  }, []);
+  });
 
   return (
     <Grid container spacing={3} style={{ fontSize: '16px' }}>
@@ -68,15 +69,17 @@ export default function WelcomeToDevonfw(): JSX.Element {
         <>
           <WelcomeSnippet></WelcomeSnippet>
           <AcceptButton
+            onClick={() => setDownloadProgress(true)}
             href={DASHBOARD_DOWNLOAD_URL}
             disabled={downloadProgress}
           >
             Download latest version
           </AcceptButton>
           <Spinner inProgress={downloadProgress}></Spinner>
-          <Box component="p" color={downloadStatusMsgColor}>
+          {/* TODO: implement alternative way to handle download */}
+          {/* <Box component="p" color={downloadStatusMsgColor}>
             {downloadStatusMsg}
-          </Box>
+          </Box> */}
         </>
       </Grid>
     </Grid>

--- a/renderer/modules/shared/components/drawer/navigation/custom-drawer/custom-drawer.tsx
+++ b/renderer/modules/shared/components/drawer/navigation/custom-drawer/custom-drawer.tsx
@@ -1,17 +1,103 @@
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { drawerLinks, DrawerLink } from './drawer-links';
 import List from '@material-ui/core/List';
 import SectionLink from '../section-link/section-link';
 import useDawerStyles from '../../drawer.style';
-import UpgradeBanner from '../../../upgrade-banner/upgrade-banner';
+import UpgradeBanner, {
+  UpgradeBannerProps,
+} from '../../../upgrade-banner/upgrade-banner';
 import ProfilePicture from '../../../profile-picture/profile-picture';
+import { IpcRendererEvent } from 'electron';
 
 interface CustomDrawerProps {
   classes: ReturnType<typeof useDawerStyles>;
 }
 
+interface IdeDistribution {
+  id: string;
+  ideConfig: {
+    basepath: string;
+    workspaces: string;
+    commands: string;
+    version: string;
+  };
+}
+
+interface DevonIdeScripts {
+  version: string;
+  updated: Date;
+}
 export default function CustomDrawer(props: CustomDrawerProps): JSX.Element {
   const router = useRouter();
+  const initialProps: UpgradeBannerProps = {
+    version: '',
+    infoText: '',
+  };
+  const [displayUpgradeBanner, setDisplayUpgradeBanner] = useState(false);
+  const [upgradeBannerProps, setUpgradeBannerProps] = useState<
+    UpgradeBannerProps
+  >(initialProps);
+
+  const getLocalLatestVersion = (versions: string[]): string => {
+    const numericVersions = versions.map((v) => {
+      return +v.split('.').join(''); // for input "2020.04.001" it will return 202004001
+    });
+    const maxVersion = Math.max(...numericVersions); // for input [202008001, 202004002, 202004004] it will return 202008001
+    const latestLocalVersion = versions.filter(
+      (v) => +v.split('.').join('') === maxVersion
+    );
+    return latestLocalVersion[0];
+  };
+
+  const updateRequired = (
+    localVersions: string[],
+    latestVersion: string
+  ): void => {
+    if (!localVersions.includes(latestVersion)) {
+      const props: UpgradeBannerProps = {
+        version: latestVersion,
+        infoText:
+          'Latest version installed in your system is ' +
+          getLocalLatestVersion(localVersions),
+      };
+      setDisplayUpgradeBanner(true);
+      setUpgradeBannerProps({ ...props });
+    }
+  };
+
+  const getLocalInstalledVersions = (mavenLatestVersion: string): void => {
+    global.ipcRenderer.send('find:devonfwInstances');
+    global.ipcRenderer.on(
+      'get:devoninstances',
+      (_: IpcRendererEvent, data: IdeDistribution[]) => {
+        if (data) {
+          const localVersions = data.map((i) => i.ideConfig.version);
+          updateRequired(localVersions, mavenLatestVersion);
+        }
+      }
+    );
+  };
+
+  const getLatesDevonIdeVersion = (): void => {
+    global.ipcRenderer.send('find:latestDevonIdeScript');
+    global.ipcRenderer.on(
+      'get:latestDevonIdeScript',
+      (_: IpcRendererEvent, data: DevonIdeScripts) => {
+        if (data) getLocalInstalledVersions(data.version);
+      }
+    );
+  };
+
+  useEffect(() => {
+    getLatesDevonIdeVersion();
+    return () => {
+      global.ipcRenderer.removeAllListeners('get:latestDevonIdeScript');
+      global.ipcRenderer.removeAllListeners('get:devoninstances');
+      global.ipcRenderer.removeAllListeners('download progress');
+      global.ipcRenderer.removeAllListeners('download completed');
+    };
+  }, []);
 
   return (
     <div>
@@ -31,7 +117,12 @@ export default function CustomDrawer(props: CustomDrawerProps): JSX.Element {
           );
         })}
       </List>
-      <UpgradeBanner></UpgradeBanner>
+      {displayUpgradeBanner ? (
+        <UpgradeBanner
+          version={upgradeBannerProps.version}
+          infoText={upgradeBannerProps.infoText}
+        ></UpgradeBanner>
+      ) : null}
     </div>
   );
 }

--- a/renderer/modules/shared/components/drawer/navigation/custom-drawer/custom-drawer.tsx
+++ b/renderer/modules/shared/components/drawer/navigation/custom-drawer/custom-drawer.tsx
@@ -14,20 +14,12 @@ interface CustomDrawerProps {
   classes: ReturnType<typeof useDawerStyles>;
 }
 
-interface IdeDistribution {
-  id: string;
-  ideConfig: {
-    basepath: string;
-    workspaces: string;
-    commands: string;
-    version: string;
-  };
+interface DevonUpdateResponse {
+  updateAvailable: boolean;
+  latestLocalVersion: string;
+  latestAvailableVersion: string;
 }
 
-interface DevonIdeScripts {
-  version: string;
-  updated: Date;
-}
 export default function CustomDrawer(props: CustomDrawerProps): JSX.Element {
   const router = useRouter();
   const initialProps: UpgradeBannerProps = {
@@ -39,52 +31,21 @@ export default function CustomDrawer(props: CustomDrawerProps): JSX.Element {
     UpgradeBannerProps
   >(initialProps);
 
-  const getLocalLatestVersion = (versions: string[]): string => {
-    const numericVersions = versions.map((v) => {
-      return +v.split('.').join(''); // for input "2020.04.001" it will return 202004001
-    });
-    const maxVersion = Math.max(...numericVersions); // for input [202008001, 202004002, 202004004] it will return 202008001
-    const latestLocalVersion = versions.filter(
-      (v) => +v.split('.').join('') === maxVersion
-    );
-    return latestLocalVersion[0];
-  };
-
-  const updateRequired = (
-    localVersions: string[],
-    latestVersion: string
-  ): void => {
-    if (!localVersions.includes(latestVersion)) {
-      const props: UpgradeBannerProps = {
-        version: latestVersion,
-        infoText:
-          'Latest version installed in your system is ' +
-          getLocalLatestVersion(localVersions),
-      };
-      setDisplayUpgradeBanner(true);
-      setUpgradeBannerProps({ ...props });
-    }
-  };
-
-  const getLocalInstalledVersions = (mavenLatestVersion: string): void => {
-    global.ipcRenderer.send('find:devonfwInstances');
-    global.ipcRenderer.on(
-      'get:devoninstances',
-      (_: IpcRendererEvent, data: IdeDistribution[]) => {
-        if (data) {
-          const localVersions = data.map((i) => i.ideConfig.version);
-          updateRequired(localVersions, mavenLatestVersion);
-        }
-      }
-    );
-  };
-
   const getLatesDevonIdeVersion = (): void => {
-    global.ipcRenderer.send('find:latestDevonIdeScript');
+    global.ipcRenderer.send('find:checkForUpdates');
     global.ipcRenderer.on(
-      'get:latestDevonIdeScript',
-      (_: IpcRendererEvent, data: DevonIdeScripts) => {
-        if (data) getLocalInstalledVersions(data.version);
+      'get:checkForUpdates',
+      (_: IpcRendererEvent, data: DevonUpdateResponse) => {
+        if (data.updateAvailable) {
+          const props: UpgradeBannerProps = {
+            version: data.latestAvailableVersion,
+            infoText:
+              'Latest version installed in your system is ' +
+              data.latestLocalVersion,
+          };
+          setDisplayUpgradeBanner(true);
+          setUpgradeBannerProps({ ...props });
+        }
       }
     );
   };
@@ -92,10 +53,7 @@ export default function CustomDrawer(props: CustomDrawerProps): JSX.Element {
   useEffect(() => {
     getLatesDevonIdeVersion();
     return () => {
-      global.ipcRenderer.removeAllListeners('get:latestDevonIdeScript');
-      global.ipcRenderer.removeAllListeners('get:devoninstances');
-      global.ipcRenderer.removeAllListeners('download progress');
-      global.ipcRenderer.removeAllListeners('download completed');
+      global.ipcRenderer.removeAllListeners('get:checkForUpdates');
     };
   }, []);
 

--- a/renderer/modules/shared/components/upgrade-banner/upgrade-banner.styles.ts
+++ b/renderer/modules/shared/components/upgrade-banner/upgrade-banner.styles.ts
@@ -2,7 +2,7 @@ import makeStyles from '@material-ui/core/styles/makeStyles';
 
 export const useUpgradeBannerStyles = makeStyles({
   updateAction: {
-    '& button': {
+    '& a': {
       marginTop: '16px',
       backgroundColor: '#0075B3',
       color: '#FFFFFF',

--- a/renderer/modules/shared/components/upgrade-banner/upgrade-banner.tsx
+++ b/renderer/modules/shared/components/upgrade-banner/upgrade-banner.tsx
@@ -1,20 +1,37 @@
 import { useUpgradeBannerStyles } from './upgrade-banner.styles';
 import Info from '@material-ui/icons/Info';
 import Button from '@material-ui/core/Button';
+import Tooltip from '@material-ui/core/Tooltip';
 
-export default function UpgradeBanner(): JSX.Element {
+export interface UpgradeBannerProps {
+  version: string;
+  infoText: string;
+}
+
+export default function UpgradeBanner(props: UpgradeBannerProps): JSX.Element {
   const classes = useUpgradeBannerStyles();
+  const DASHBOARD_DOWNLOAD_URL =
+    'https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.devonfw.tools.ide&a=devonfw-ide-scripts&v=LATEST&p=tar.gz';
+
   return (
     <div className={classes.upgrade}>
       <div>
         <div>
           <h4 className={classes.uppercase}>
-            Latest version 3.0.1 <Info />
+            Latest version {props.version}
+            <Tooltip title={props.infoText} placement="top" arrow>
+              <Info fontSize="small" />
+            </Tooltip>
           </h4>
           <div>Get IDE fixes and more Features </div>
         </div>
         <div className={classes.updateAction}>
-          <Button variant="contained" color="primary" size="large">
+          <Button
+            variant="contained"
+            color="primary"
+            size="large"
+            href={DASHBOARD_DOWNLOAD_URL}
+          >
             UPDATE NOW
           </Button>
         </div>


### PR DESCRIPTION
I am displaying the "upgrade" banner component in the sidebar only if there is a version available which is newer than the ones setup locally on the user machine. For the info icon in the component, I am displaying the latest version locally setup in a tooltip.

TODO: Need an alternative approach to handle downloads as the current one impacts all components globally. (Success/error message on download completion has been disabled on the Home page for this reason).